### PR TITLE
Update gettext release

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,8 +2,8 @@ markdown: kramdown
 permalink: /:categories/blog/:year/:month/:day/:title.html
 paginate: 5
 url: http://ruby-gettext.github.io
-gettext_version: 3.2.4
-gettext_release_date: 2017-08-13
+gettext_version: 3.2.9
+gettext_release_date: 2018-03-05
 locale_version: 2.1.2
 locale_release_date: 2015-09-15
 


### PR DESCRIPTION
According to https://rubygems.org/gems/gettext

The last version of gettext gem is 3.2.9 and it was released at March 05, 2018

cc: @kou 